### PR TITLE
recover from local NaNs

### DIFF
--- a/lib/training/noop.py
+++ b/lib/training/noop.py
@@ -39,7 +39,10 @@ class IgnoreGradManipulations(nn.Module):
         return self.module.forward(*args, **kwargs)
 
     def zero_grad(self, set_to_none: bool = False) -> None:
-        logger.debug("Successfully bypassed zero_grad")
+        if all(param.grad.isfinite().all() for param in self.parameters()):
+            logger.debug("Successfully bypassed zero_grad")
+        else:
+            self.module.zero_grad()
 
     def clip_grad_norm_(self, *args, **kwargs):
         """ ignore clip_grad_norm on each step, clip in optimizer instead """


### PR DESCRIPTION
over the 6 test hours of training, one of the trainers hang because it encountered NaN in the fp16 gradients

HuggingFace trained had a mechanism for recovering from NaN gradients, but, turned out, we accidentally disabled it.

This PR allows trainer to ignore NaN gradients and continue training