### PR TITLE
[hotfix] Fix logging message line multiple times

### DIFF
--- a/huggingface_auth.py
+++ b/huggingface_auth.py
@@ -13,7 +13,7 @@ from hivemind.utils.crypto import RSAPublicKey
 from hivemind.utils.logging import get_logger
 
 
-logger = get_logger(__name__)
+logger = get_logger("root." + __name__)
 
 
 class NonRetriableError(Exception):


### PR DESCRIPTION
Currently, some messages in Colab and Kaggle notebooks are logged twice due to a bug in `hivemind.utils.logging`:

<img width="1329" alt="Screen Shot 2021-09-04 at 6 50 53 AM" src="https://user-images.githubusercontent.com/8748943/132081631-302d362f-e8d2-44b4-81d2-59b34a223000.png">

This PR contains a hot fix for this problem. See https://github.com/learning-at-home/hivemind/pull/378 for the explanation and a more thorough fix.