### PR TITLE
Disable reuse_grad_buffers

### DIFF
--- a/run_trainer.py
+++ b/run_trainer.py
@@ -179,7 +179,7 @@ def main(index: Optional[int] = None):
         compression=averaging_compression, state_compression=Float16Compression(),
         batch_size_per_step=total_batch_size_per_step, bandwidth=collaboration_args.bandwidth,
         target_batch_size=adjusted_target_batch_size, client_mode=collaboration_args.client_mode,
-        reuse_grad_buffers=True, verbose=True, start=True, **asdict(averager_args),
+        reuse_grad_buffers=False, verbose=True, start=True, **asdict(averager_args),
     )
 
     collaborative_training_callback = callback.CollaborativeCallback(


### PR DESCRIPTION
This is a memory optimization that may in some cases behave incorrectly.

The issue surfaces when aggregating multple steps with torch.amp and [grad_scaler.unscale_](https://pytorch.org/docs/stable/_modules/torch/cuda/amp/grad_scaler.html#GradScaler.unscale_) in particular.

The HF trainer with CollaborativeOptimizer(reuse_grad_buffers=True) may sometimes apply unscale more than once to the same grad buffer, which causes partial loss of the accumulated gradients. This PR fixes the issue by temporarily disabling the optimization.