### PR TITLE
further sanity check for correct fp16 grads

### DIFF
--- a/lib/training/noop.py
+++ b/lib/training/noop.py
@@ -31,19 +31,24 @@ class NoOpScheduler(LRSchedulerBase):
 
 class IgnoreGradManipulations(nn.Module):
     """ Wrapper for model that blocks gradient manipulations in huggingface Trainer (e.g. zero_grad, clip_grad) """
-    def __init__(self, module):
+    def __init__(self, module, override_clipping: bool = True, override_zero_grad: bool = True):
         super().__init__()
         self.module = module
+        self.override_clipping = override_clipping
+        self.override_zero_grad = override_zero_grad
 
     def forward(self, *args, **kwargs):
         return self.module.forward(*args, **kwargs)
 
     def zero_grad(self, set_to_none: bool = False) -> None:
-        if all(param.grad.isfinite().all() for param in self.parameters()):
+        if self.override_zero_grad and all(param.grad.isfinite().all() for param in self.parameters()):
             logger.debug("Successfully bypassed zero_grad")
         else:
-            self.module.zero_grad()
+            self.module.zero_grad(set_to_none=set_to_none)
 
-    def clip_grad_norm_(self, *args, **kwargs):
+    def clip_grad_norm_(self, max_norm: float, norm_type: int = 2):
         """ ignore clip_grad_norm on each step, clip in optimizer instead """
-        logger.debug("Successfully bypassed clip_grad_norm_")
+        if self.override_clipping:
+            logger.debug("Successfully bypassed clip_grad_norm_")
+        else:
+            return torch.nn.utils.clip_grad_norm_(self.module.parameters(), max_norm, norm_type=norm_type)

--- a/run_trainer.py
+++ b/run_trainer.py
@@ -122,7 +122,8 @@ class TrainerWithIndependentShuffling(Trainer):
         return super().get_train_dataloader()
 
     def _wrap_model(self, model, training=True):
-        return IgnoreGradManipulations(super()._wrap_model(model, training=training), override_zero_grad=False)
+        return IgnoreGradManipulations(super()._wrap_model(model, training=training),
+                                       override_clipping=True, override_zero_grad=False)
 
 
 def main(index: Optional[int] = None):

--- a/run_trainer.py
+++ b/run_trainer.py
@@ -122,7 +122,7 @@ class TrainerWithIndependentShuffling(Trainer):
         return super().get_train_dataloader()
 
     def _wrap_model(self, model, training=True):
-        return IgnoreGradManipulations(super()._wrap_model(model, training=training))
+        return IgnoreGradManipulations(super()._wrap_model(model, training=training), override_zero_grad=False)
 
 
 def main(index: Optional[int] = None):


### PR DESCRIPTION
This PR restores model.zero_grad calls that were previously bypassed when we had `reuse_grad_buffers=False`

The bypass is no longer necessary after #5 