### PR TITLE
Colab devs have broken torch_xla, this is a hotfix

### DIFF
--- a/lib/training/tpu.py
+++ b/lib/training/tpu.py
@@ -221,3 +221,6 @@ class QueueDataset(torch.utils.data.IterableDataset):
     def __iter__(self):
         while True:
             yield self.queue.get()
+
+    def __len__(self):
+        return float('inf')

--- a/lib/training/tpu.py
+++ b/lib/training/tpu.py
@@ -223,4 +223,4 @@ class QueueDataset(torch.utils.data.IterableDataset):
             yield self.queue.get()
 
     def __len__(self):
-        return float('inf')
+        return 10 ** 12  # TODO deprecate this when the issue is resolved: https://github.com/googlecolab/colabtools/issues/2237


### PR DESCRIPTION
Yesterday, colab folks have updated their torch binaries and the new ones are subtly broken :)

Here's their issue: https://github.com/googlecolab/colabtools/issues/2237

This PR allows us to rollback torch_xla to v1.8 that is not broken.

__You will also need to add the new installation code for TPU:__

```
import os
assert os.environ['COLAB_TPU_ADDR'], 'Make sure to select TPU from Edit > Notebook settings > Hardware accelerator'

print("INSTALLING REQUIREMENTS: This might take few minutes...")
!pip install -q https://github.com/learning-at-home/hivemind/archive/sahaj2.zip
!git clone -q https://github.com/tanmoyio/sahajbert
!pip install -q -r sahajbert/requirements.txt
!pip uninstall -y -q torch
!pip install -q torch==1.8.2+cpu -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html &> ./log
!pip install -q cloud-tpu-client==0.10 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.8-cp37-cp37m-linux_x86_64.whl &> ./log

%cd sahajbert

from shlex import quote
import torch
from huggingface_auth import authorize_with_huggingface

%env HF_EXPERIMENT_ID=15
authorizer = authorize_with_huggingface()

!ulimit -n 4096
!WANDB_API_KEY=61612ca9b99e6a477893d7eb93a390462543fe7f HF_EXPERIMENT_ID=15 HF_USERNAME={quote(authorizer.username)} HF_PASSWORD={quote(authorizer.password)} python run_trainer_tpu.py \
 --run_name {quote(authorizer.username)} --experiment_prefix sahajbert-xlarge --initial_peers /ip4/45.79.126.160/tcp/45261/p2p/QmdbwdztAmpw5Pzu9YR1S7ZTqfBWPWzYtB543oGdBnwpmb /ip4/52.232.13.142/tcp/42223/p2p/QmWMNBvt3VkVETzQ68Uk44PokVjwA8sSvEEB3z8WwA5ZAS \
 --client_mode --gradient_accumulation_steps 1 --per_device_train_batch_size=4
```

The GPU notebooks are not affected