### PR TITLE
Support TPUv3 for kaggle

### DIFF
--- a/lib/models/lean_albert.py
+++ b/lib/models/lean_albert.py
@@ -129,12 +129,8 @@ class LeanAlbertLayer(nn.Module):
                            layer_norm_eps=config.layer_norm_eps, dropout=config.hidden_dropout_prob)
 
     def forward(self, hidden_states, attention_mask=None, output_attentions=False):
-        print('pre-ATTN')
         attention_output, *extras = self.attention(hidden_states, attention_mask, output_attentions)
-        print('post-ATTN')
-        print('pre-FFN')
         ffn_output = self.ffn(attention_output)
-        print('post-FFN')
         return (ffn_output, attention_output, *extras)
 
 
@@ -188,16 +184,13 @@ class LeanAlbertTransformer(AlbertTransformer):
         output_hidden_states=False,
         return_dict=True,
     ):
-        print('---1')
         #TODO this should entire be replaced with inheritance and post_layer_norm
         hidden_states = self.embedding_hidden_mapping_in(hidden_states)
 
         all_hidden_states = (hidden_states,) if output_hidden_states else None
         all_attentions = () if output_attentions else None
-        print('---2')
 
         for i in range(self.config.num_hidden_layers):
-            print('---LG', i)
             # Number of layers in a hidden group
             layers_per_group = int(self.config.num_hidden_layers / self.config.num_hidden_groups)
 

--- a/lib/models/lean_albert.py
+++ b/lib/models/lean_albert.py
@@ -129,8 +129,12 @@ class LeanAlbertLayer(nn.Module):
                            layer_norm_eps=config.layer_norm_eps, dropout=config.hidden_dropout_prob)
 
     def forward(self, hidden_states, attention_mask=None, output_attentions=False):
+        print('pre-ATTN')
         attention_output, *extras = self.attention(hidden_states, attention_mask, output_attentions)
+        print('post-ATTN')
+        print('pre-FFN')
         ffn_output = self.ffn(attention_output)
+        print('post-FFN')
         return (ffn_output, attention_output, *extras)
 
 
@@ -184,13 +188,16 @@ class LeanAlbertTransformer(AlbertTransformer):
         output_hidden_states=False,
         return_dict=True,
     ):
+        print('---1')
         #TODO this should entire be replaced with inheritance and post_layer_norm
         hidden_states = self.embedding_hidden_mapping_in(hidden_states)
 
         all_hidden_states = (hidden_states,) if output_hidden_states else None
         all_attentions = () if output_attentions else None
+        print('---2')
 
         for i in range(self.config.num_hidden_layers):
+            print('---LG', i)
             # Number of layers in a hidden group
             layers_per_group = int(self.config.num_hidden_layers / self.config.num_hidden_groups)
 

--- a/lib/modules/rotary.py
+++ b/lib/modules/rotary.py
@@ -54,7 +54,7 @@ def get_auxiliary_tensors(seq_len: int, dim: int, dtype: torch.dtype, device: to
     print('?-5')
     cos = torch.cos(freqs)
     print('?-6')
-    sin = torch.sin(freqs, out=freqs)
+    sin = freqs.sin_()
     print('?-7')
     try:
         return cos.to(dtype), sin.to(dtype)

--- a/lib/modules/rotary.py
+++ b/lib/modules/rotary.py
@@ -19,19 +19,12 @@ class RotaryEmbeddings(nn.Module):
         :param x: tensor of shape [batch_size, seq_len, nhead, hid_size]
         :param offset: add this value to all position indices
         """
-        print('!!!A')
         seq_len = x.shape[1]
-        print('!!!B')
         cos, sin = getattr(self, 'cos', None), getattr(self, 'sin', None)
-        print('!!!C')
         if cos is None or seq_len + offset >= cos.shape[0] or x.dtype != cos.dtype or x.device != cos.device:
-            print('!!!D')
             cos, sin = get_auxiliary_tensors(seq_len + offset, self.dim, x.dtype, x.device, self.base)
-            print('!!!E')
             self.register_buffer('cos', cos)
-            print('!!!F')
             self.register_buffer('sin', sin)
-            print('!!!G')
 
         return rotate(x, cos[None, offset: seq_len + offset, None, :], sin[None, offset: seq_len + offset, None, :])
 
@@ -42,32 +35,19 @@ def get_auxiliary_tensors(seq_len: int, dim: int, dtype: torch.dtype, device: to
     Compute auxiliary sine and cosine tensors for rotary position embedding
     :returns: a tuple of (cos, sin) tensors of shape [seq_len, hid_size]
     """
-    print('?-1')
     _buf = torch.linspace(0, -1 + 2 / dim, dim // 2, dtype=torch.float32, device=device)
-    print('?-2')
     inv_freq = torch.pow(base, _buf, out=_buf).repeat(2)
-    print('?-3')
     time_ix = torch.arange(seq_len, dtype=inv_freq.dtype, device=device)
-    print('?-4')
 
     freqs = (time_ix[:, None] * inv_freq[None, :])
-    print('?-5')
     cos = torch.cos(freqs)
-    print('?-6')
     sin = freqs.sin_()
-    print('?-7')
-    try:
-        return cos.to(dtype), sin.to(dtype)
-    finally:
-        print('?-8')
+    return cos.to(dtype), sin.to(dtype)
 
 
 def rotate(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
     """ rotate pairwise coordinate using precomputed cos & sin tensors """
     dim = x.shape[-1]
-    print('H')
     x_left, x_right = x.split(split_size=dim // 2, dim=x.ndim - 1)
-    print('I')
     x_rotated = torch.cat([x_right.neg(), x_left], dim=x.ndim - 1)
-    print('J')
     return x * cos + x_rotated * sin

--- a/lib/modules/rotary.py
+++ b/lib/modules/rotary.py
@@ -19,12 +19,19 @@ class RotaryEmbeddings(nn.Module):
         :param x: tensor of shape [batch_size, seq_len, nhead, hid_size]
         :param offset: add this value to all position indices
         """
+        print('!!!A')
         seq_len = x.shape[1]
+        print('!!!B')
         cos, sin = getattr(self, 'cos', None), getattr(self, 'sin', None)
+        print('!!!C')
         if cos is None or seq_len + offset >= cos.shape[0] or x.dtype != cos.dtype or x.device != cos.device:
+            print('!!!D')
             cos, sin = get_auxiliary_tensors(seq_len + offset, self.dim, x.dtype, x.device, self.base)
+            print('!!!E')
             self.register_buffer('cos', cos)
+            print('!!!F')
             self.register_buffer('sin', sin)
+            print('!!!G')
 
         return rotate(x, cos[None, offset: seq_len + offset, None, :], sin[None, offset: seq_len + offset, None, :])
 
@@ -48,6 +55,9 @@ def get_auxiliary_tensors(seq_len: int, dim: int, dtype: torch.dtype, device: to
 def rotate(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
     """ rotate pairwise coordinate using precomputed cos & sin tensors """
     dim = x.shape[-1]
+    print('H')
     x_left, x_right = x.split(split_size=dim // 2, dim=x.ndim - 1)
+    print('I')
     x_rotated = torch.cat([x_right.neg(), x_left], dim=x.ndim - 1)
+    print('J')
     return x * cos + x_rotated * sin

--- a/lib/modules/rotary.py
+++ b/lib/modules/rotary.py
@@ -42,14 +42,24 @@ def get_auxiliary_tensors(seq_len: int, dim: int, dtype: torch.dtype, device: to
     Compute auxiliary sine and cosine tensors for rotary position embedding
     :returns: a tuple of (cos, sin) tensors of shape [seq_len, hid_size]
     """
+    print('?-1')
     _buf = torch.linspace(0, -1 + 2 / dim, dim // 2, dtype=torch.float32, device=device)
+    print('?-2')
     inv_freq = torch.pow(base, _buf, out=_buf).repeat(2)
+    print('?-3')
     time_ix = torch.arange(seq_len, dtype=inv_freq.dtype, device=device)
+    print('?-4')
 
     freqs = (time_ix[:, None] * inv_freq[None, :])
+    print('?-5')
     cos = torch.cos(freqs)
+    print('?-6')
     sin = torch.sin(freqs, out=freqs)
-    return cos.to(dtype), sin.to(dtype)
+    print('?-7')
+    try:
+        return cos.to(dtype), sin.to(dtype)
+    finally:
+        print('?-8')
 
 
 def rotate(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:

--- a/lib/training/tpu.py
+++ b/lib/training/tpu.py
@@ -49,7 +49,11 @@ class TPUManager(mp.Process):
             self.start()
 
     def run(self):
-        return xmp.spawn(self.runner, nprocs=self.nprocs, start_method='fork')
+        thread = threading.Thread(
+            target=partial(xmp.spawn, self.runner, nprocs=self.nprocs, start_method='fork'),
+            daemon=True)
+        thread.start()
+        thread.join()
 
     def update_model_parameters(self, new_host_parameters):
         """Schedule TPUs to update model parameters during at the beginning of the next step"""

--- a/lib/training/tpu.py
+++ b/lib/training/tpu.py
@@ -203,6 +203,9 @@ class TPUSynchronizer:
                 assert source_tensor.dtype == target_tensor.dtype
             if add:
                 print('--D4')
+                print(target_tensor.shape, source_tensor.shape, target_tensor.dtype, source_tensor.dtype)
+                print(target_tensor)
+                print(source_tensor)
                 target_tensor.add_(source_tensor)
                 print('--D5')
             else:

--- a/lib/training/tpu.py
+++ b/lib/training/tpu.py
@@ -84,7 +84,6 @@ class TPUManager(mp.Process):
     def runner(self, tpu_index):
         """Run training steps from the perspective of a single TPU core"""
         # acquire the (unique) Cloud TPU core corresponding to this process's index
-
         device = xm.xla_device()
         logger.info(f"Process {tpu_index} is using {xm.xla_real_devices([str(device)])[0]}")
 

--- a/lib/training/tpu.py
+++ b/lib/training/tpu.py
@@ -164,9 +164,9 @@ class TPUSynchronizer:
 
     def get_device_model_replica(self, device: torch.device, tie_weights: bool = True):
         print('A')
-        replica = deepcopy(self.master_model)
+        # replica = deepcopy()
         print('A2')
-        replica = replica.to(device)
+        replica = self.master_model.to(device)
         print('B')
         if tie_weights:
             replica.tie_weights()

--- a/lib/training/tpu.py
+++ b/lib/training/tpu.py
@@ -163,11 +163,15 @@ class TPUSynchronizer:
             param.grad = param.grad.share_memory_()
 
     def get_device_model_replica(self, device: torch.device, tie_weights: bool = True):
+        print('A')
         replica = deepcopy(self.master_model).to(device)
+        print('B')
         if tie_weights:
             replica.tie_weights()
+        print('C')
         for param in replica.parameters():
             param.grad = torch.zeros_like(param, device=device)
+            print('D')
         return replica
 
     def set_host_parameters(self, new_host_parameters):

--- a/lib/training/tpu.py
+++ b/lib/training/tpu.py
@@ -79,13 +79,15 @@ class TPUManager(mp.Process):
 
     def runner(self, tpu_index):
         """Run training steps from the perspective of a single TPU core"""
-
+        print(1)
         # acquire the (unique) Cloud TPU core corresponding to this process's index
         device = xm.xla_device()
         logger.info(f"Process {tpu_index} is using {xm.xla_real_devices([str(device)])[0]}")
+        print(2)
 
         # set random seed for
         torch.manual_seed(self.seed_base + tpu_index)
+        print(3)
 
         if self.staged_init:
             # use staged init to minimize peak RAM usage
@@ -98,10 +100,14 @@ class TPUManager(mp.Process):
                     data_loader_iter = iter(data_loader)
                     logger.info(f"Process {tpu_index} initialized.")
         else:
+            print(4)
             model = self._synchronizer.get_device_model_replica(device)
+            print(5)
             data_loader = self._data_manager.get_device_dataloader(
                 batch_size=self.batch_size, num_workers=0, collate_fn=self.collate_fn, pin_memory=False)
+            print(6)
             data_loader_iter = iter(data_loader)
+            print(7)
             logger.info(f"Process {tpu_index} initialized.")
 
             

--- a/lib/training/tpu.py
+++ b/lib/training/tpu.py
@@ -117,14 +117,22 @@ class TPUManager(mp.Process):
             ### compute loss and gradients
             loss = 0.0
             for i in range(self.grad_accumulation_steps):
+                print('3a')
                 inputs = next(data_loader_iter)
+                print('3b')
                 outputs = model(**inputs)
+                print('3c')
                 loss_i = outputs["loss"] if isinstance(outputs, dict) else outputs[0]
+                print('3d')
                 loss_i = loss_i / (self.grad_accumulation_steps * self.nprocs)
+                print('3e')
                 loss_i.backward()
+                print('3f')
                 loss += loss_i
+                print('3g')
                 del inputs, outputs, loss_i
-
+                print('3h')
+                
             print('4')
 
             ### aggregate gradients from TPUs

--- a/lib/training/tpu.py
+++ b/lib/training/tpu.py
@@ -49,6 +49,8 @@ class TPUManager(mp.Process):
             self.start()
 
     def run(self):
+        import threading
+        from functools import partial
         thread = threading.Thread(
             target=partial(xmp.spawn, self.runner, nprocs=self.nprocs, start_method='fork'),
             daemon=True)

--- a/lib/training/tpu.py
+++ b/lib/training/tpu.py
@@ -164,7 +164,9 @@ class TPUSynchronizer:
 
     def get_device_model_replica(self, device: torch.device, tie_weights: bool = True):
         print('A')
-        replica = deepcopy(self.master_model).to(device)
+        replica = deepcopy(self.master_model)
+        print('A2')
+        replica = replica.to(device)
         print('B')
         if tie_weights:
             replica.tie_weights()

--- a/run_trainer_tpu.py
+++ b/run_trainer_tpu.py
@@ -131,14 +131,14 @@ def main():
     collaborative_training_callback.on_train_begin(training_args, state, control)
     tpu_manager.update_model_parameters(model.parameters())
 
-    wandb.init(project="huggingface")
+    wandb.init(project="huggingface", name=training_args.run_name)
 
     while True:
         start_time = time.perf_counter()
         loss, num_accumulated = tpu_manager.step()
         time_delta = time.perf_counter() - start_time
         logger.info(f"Accumulated {num_accumulated} gradients at {num_accumulated / time_delta:.3f} samples/second.")
-        wandb.log({"train/loss": loss})
+        wandb.log({"train/loss": loss, "train/learning_rate": collaborative_optimizer.scheduler.get_lr()})
 
         with torch.no_grad():
             for param, grad_from_tpu in zip(model.parameters(), tpu_manager.get_aggregated_gradients()):

--- a/run_trainer_tpu.py
+++ b/run_trainer_tpu.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 import multiprocessing as mp
 from typing import Any
 
+import wandb
 from hivemind import CollaborativeOptimizer
 
 from callback import CollaborativeCallback
@@ -130,11 +131,14 @@ def main():
     collaborative_training_callback.on_train_begin(training_args, state, control)
     tpu_manager.update_model_parameters(model.parameters())
 
+    wandb.init(project="huggingface")
+
     while True:
         start_time = time.perf_counter()
         loss, num_accumulated = tpu_manager.step()
         time_delta = time.perf_counter() - start_time
         logger.info(f"Accumulated {num_accumulated} gradients at {num_accumulated / time_delta:.3f} samples/second.")
+        wandb.log({"train/loss": loss})
 
         with torch.no_grad():
             for param, grad_from_tpu in zip(model.parameters(), tpu_manager.get_aggregated_gradients()):

--- a/run_trainer_tpu.py
+++ b/run_trainer_tpu.py
@@ -138,7 +138,7 @@ def main():
         loss, num_accumulated = tpu_manager.step()
         time_delta = time.perf_counter() - start_time
         logger.info(f"Accumulated {num_accumulated} gradients at {num_accumulated / time_delta:.3f} samples/second.")
-        wandb.log({"train/loss": loss, "train/learning_rate": collaborative_optimizer.scheduler.get_lr()})
+        wandb.log({"train/loss": loss, "train/learning_rate": collaborative_optimizer.scheduler.get_lr()[0]})
 
         with torch.no_grad():
             for param, grad_from_tpu in zip(model.parameters(), tpu_manager.get_aggregated_gradients()):


### PR DESCRIPTION
This patch fixes several issues that previously caused kaggle to hang.

Specifically, some operations (with out=...) are now replaced with pytorch-specific in-place ops such as `x.sin_()`.

Also, starting TPUManager with concurrent pytorch ops would previously cause it to lock pytorch built-in thread pool in an invalid state, which would result in freezes when working with self.master_model shared tensors. To address this, we're now creating a new thread inside TPUManager.run before forking the TPU processes.

Finally, we need to slightly modify the starter script to make it work on kaggle TPU. From what i know about kaggle, this script *should* work, but __please check it for yourself before distributing!__

```python
import os
assert os.environ['TPU_NAME'], 'Make sure to select TPU from the Accelerator menu on the right'

print("INSTALLING REQUIREMENTS: This might take few minutes...")
!pip install -q https://github.com/learning-at-home/hivemind/archive/sahaj2.zip &> ./log
!git clone -q https://github.com/tanmoyio/sahajbert &> ./log
!pip install -q -r sahajbert/requirements.txt &> ./log
!pip uninstall -y -q torch &> ./log
!pip install -q torch==1.8.2+cpu -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html &> ./log
!pip install -q cloud-tpu-client==0.10 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.8-cp37-cp37m-linux_x86_64.whl &> ./log
!pip install --upgrade transformers==4.10.2 datasets==1.11.0 &> ./log

%cd sahajbert

from shlex import quote
import torch
from huggingface_auth import authorize_with_huggingface

%env HF_EXPERIMENT_ID=15
authorizer = authorize_with_huggingface()

!ulimit -n 4096
!WANDB_API_KEY=61612ca9b99e6a477893d7eb93a390462543fe7f HF_EXPERIMENT_ID=15 HF_USERNAME={quote(authorizer.username)} HF_PASSWORD={quote(authorizer.password)} python run_trainer_tpu.py \
 --run_name {quote(authorizer.username)} --experiment_prefix sahajbert-xlarge --initial_peers /ip4/45.79.126.160/tcp/45261/p2p/QmdbwdztAmpw5Pzu9YR1S7ZTqfBWPWzYtB543oGdBnwpmb /ip4/52.232.13.142/tcp/42223/p2p/QmWMNBvt3VkVETzQ68Uk44PokVjwA8sSvEEB3z8WwA5ZAS \
 --client_mode --gradient_accumulation_steps 3 --per_device_train_batch_size=8

```

If it works, you may want to update the instruction and explicitly request people to choose TPU in the drop-down menu.